### PR TITLE
import threading instead of thread

### DIFF
--- a/mouse.py
+++ b/mouse.py
@@ -2,7 +2,7 @@ import cv2
 import numpy as np
 import pyautogui as gui
 import pickle
-import thread
+import threading
 gui.FAILSAFE = False
 
 def top(collection, key, n):


### PR DESCRIPTION
Import threading instead of thread in python3 to rectify the "import thread error".